### PR TITLE
Update IcyVeinsStatPriority.toc

### DIFF
--- a/IcyVeinsStatPriority.toc
+++ b/IcyVeinsStatPriority.toc
@@ -1,4 +1,4 @@
-## Interface: 90000
+## Interface: 90001
 ## Title: |cff69CCF0Icy Veins|r Stat Priority
 ## Version: 2020-10-15
 ## Author: fyhcslb


### PR DESCRIPTION
Interface version number 90000 renders an outdated warning, I suggest altering it to 90001